### PR TITLE
🔧 Route compute CI to local self-hosted runner.

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,7 @@
 name: Clippy
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/clippy.yml'
@@ -13,7 +14,7 @@ on:
 jobs:
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,5 +1,6 @@
 name: Format
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/fmt.yml'
@@ -12,7 +13,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/test.yml'
@@ -13,7 +14,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Route compute-heavy Linux CI jobs to the org-level local self-hosted runner (labels: self-hosted, linux, x64, local).

- Linux compute jobs: keep auto-triggering on push/PR, now execute on the local runner.
- macOS/Windows matrix legs: manual `workflow_dispatch` only.
- Merge hooks (commit-msg-lint / pr-title-check / squash-msg-clean), tag/release workflows, and Pages deploys stay on GitHub-hosted runners.
- evernight: re-enables workflows previously paused via __billing-paused__.
- entelecheia: fixes a pre-existing YAML block-scalar bug in install-test.yml.