### PR TITLE
✨ Add merge patch diff and dotted path runtime modules.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["macros"]
 exclude = ["tests/across_crate_entry", "tests/across_crate_lib"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["langyo <langyo.china@gmail.com>"]
@@ -30,7 +30,7 @@ all-features = true
 [dependencies]
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
-yuuka-macros = { path = "macros", version = "0.7.0" }
+yuuka-macros = { path = "macros", version = "0.8.0" }
 
 [dev-dependencies]
 anyhow = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ publish = true
 all-features = true
 
 [dependencies]
+serde = { version = "^1", features = ["derive"] }
+serde_json = "^1"
 yuuka-macros = { path = "macros", version = "0.7.0" }
 
 [dev-dependencies]
 anyhow = "^1"
-serde = { version = "^1", features = ["derive"] }
-serde_json = "^1"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,141 @@
+//! Before/after diffing into [`PatchOp`] lists.
+//!
+//! [`diff`] walks two versions of a state tree and emits the op set that
+//! reconstructs `after` from `before`:
+//!
+//! - both sides objects → recurse per key over the union; added/changed
+//!   keys yield `set` ops, removed keys yield `del` ops;
+//! - values differing (at least one side not an object) → a single `set` of
+//!   the new value at the current path;
+//! - equal values → no op.
+//!
+//! All generated paths are prefixed with `prefix` (usually `state`), so the
+//! same trees can be diffed at any sub-root. Roundtrip guarantee:
+//! `apply_all(before.clone(), diff(prefix, &before, &after)) == after` —
+//! pinned by the property-based test in `tests/patch_compat.rs`, for the
+//! state-tree domain where object members carry no explicit `null`s (the
+//! one RFC 7396 caveat: a `null` member inside a wholesale-written object
+//! value cannot survive the deep merge; nulls as whole leaf values
+//! roundtrip fine).
+
+use serde_json::Value;
+
+use crate::patch::PatchOp;
+use crate::path::join;
+
+/// Diffs two versions of a state tree into the op list that transforms
+/// `before` into `after`. See the module docs for the strategy.
+pub fn diff(prefix: &str, before: &Value, after: &Value) -> Vec<PatchOp> {
+    let mut ops = Vec::new();
+    diff_into(prefix, before, after, &mut ops);
+    ops
+}
+
+fn diff_into(prefix: &str, before: &Value, after: &Value, ops: &mut Vec<PatchOp>) {
+    match (before, after) {
+        (Value::Object(b), Value::Object(a)) => {
+            // Keys that vanished → del.
+            for k in b.keys() {
+                if !a.contains_key(k) {
+                    ops.push(PatchOp::del(join(prefix, k)));
+                }
+            }
+            // Keys that were added or changed → set / recurse.
+            for (k, av) in a {
+                let path = join(prefix, k);
+                match b.get(k) {
+                    None => ops.push(PatchOp::set(path, av.clone())),
+                    Some(bv) => diff_into(&path, bv, av, ops),
+                }
+            }
+        }
+        (b, a) if b == a => {
+            // Identical values → no op.
+        }
+        (_, a) => {
+            // Different values (at least one non-object) → set the new one.
+            ops.push(PatchOp::set(prefix.to_string(), a.clone()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    use crate::patch::{apply_all, PatchKind};
+
+    // Ported from plana `packages/sync/src/patch.rs` (compat baseline).
+
+    #[test]
+    fn diff_detects_add_change_remove() {
+        let before = json!({"hubris":{"status":"idle"},"kalos":{"status":"busy"}});
+        let after = json!({"hubris":{"status":"busy","model":"glm"},"seia":{"status":"idle"}});
+        let ops = diff("state.agents", &before, &after);
+        // kalos deleted, hubris.status changed + hubris.model added, seia added.
+        let has_del_kalos = ops
+            .iter()
+            .any(|o| o.op == PatchKind::Del && o.path == "state.agents.kalos");
+        let has_set_hubris_status = ops.iter().any(|o| {
+            o.op == PatchKind::Set
+                && o.path == "state.agents.hubris.status"
+                && o.value == Some(json!("busy"))
+        });
+        let has_set_hubris_model = ops.iter().any(|o| {
+            o.op == PatchKind::Set
+                && o.path == "state.agents.hubris.model"
+                && o.value == Some(json!("glm"))
+        });
+        let has_set_seia = ops.iter().any(|o| {
+            o.op == PatchKind::Set
+                && o.path == "state.agents.seia"
+                && o.value == Some(json!({"status":"idle"}))
+        });
+        assert!(has_del_kalos, "missing del kalos: {ops:?}");
+        assert!(has_set_hubris_status, "missing set hubris.status: {ops:?}");
+        assert!(has_set_hubris_model, "missing set hubris.model: {ops:?}");
+        assert!(has_set_seia, "missing set seia: {ops:?}");
+    }
+
+    #[test]
+    fn diff_identical_emits_nothing() {
+        let v = json!({"a":{"b":1}});
+        assert!(diff("state", &v, &v).is_empty());
+    }
+
+    #[test]
+    fn apply_then_diff_roundtrip() {
+        // before --apply(ops)--> after; diff(before, after) must produce an
+        // op set that rebuilds after (applying it back to before).
+        let before = json!({"agents":{"hubris":{"status":"idle"}}});
+        let mut root = before.clone();
+        apply_all(
+            &mut root,
+            &[
+                PatchOp::set("agents.hubris.status", json!("busy")),
+                PatchOp::set("agents.seia", json!({"status":"idle"})),
+            ],
+        );
+        let after = root.clone();
+        let ops = diff("", &before, &after);
+        let mut rebuilt = before;
+        apply_all(&mut rebuilt, &ops);
+        assert_eq!(rebuilt, after);
+    }
+
+    // Additional coverage beyond the plana baseline.
+
+    #[test]
+    fn diff_non_object_change_sets_leaf() {
+        // Object → scalar and scalar → object both collapse to a single
+        // leaf `set`, never recursing into non-objects.
+        let before = json!({"a":{"b":[1,2]}});
+        let after = json!({"a":{"b":"done"}});
+        let ops = diff("state", &before, &after);
+        assert_eq!(ops, vec![PatchOp::set("state.a.b", json!("done"))]);
+
+        let ops = diff("state", &after, &before);
+        assert_eq!(ops, vec![PatchOp::set("state.a.b", json!([1, 2]))]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-//! Nested structure derivation macros for Rust.
+//! Nested structure derivation macros for Rust, plus the runtime half of
+//! the state-tree synchronization protocol.
+//!
+//! # Macros
 //!
 //! This crate is the public facade of the `yuuka` macro family: the
 //! procedural macros themselves live in [`yuuka_macros`] and are re-exported
@@ -8,5 +11,25 @@
 //! - [`derive_struct!`] generates nested structs from a concise DSL-like syntax.
 //! - [`derive_enum!`] generates enums (and associated structs) from the same syntax.
 //! - [`auto!`] constructs values of the generated types with value-only syntax.
+//!
+//! # State patch runtime
+//!
+//! Alongside the macros, yuuka ships the runtime modules of the state-tree
+//! synchronization protocol (migrated from `plana` `packages/sync`):
+//!
+//! - [`patch`]: [`PatchOp`](patch::PatchOp) — a single `set` / `replace` /
+//!   `del` operation on a dotted path, with a serde wire format that stays
+//!   byte-compatible with the `Sync.StatePatch` notification.
+//! - [`merge`]: [`merge_patch`](merge::merge_patch) — the RFC 7396 JSON
+//!   Merge Patch core behind `set` operations.
+//! - [`diff`]: [`diff`](diff::diff) — turn a before/after state pair into
+//!   the op list that reconstructs `after` from `before`.
+//! - [`path`]: dotted-path helpers (`split` / `join` / `segments` /
+//!   `display`) shared by the modules above.
 
 pub use yuuka_macros::*;
+
+pub mod diff;
+pub mod merge;
+pub mod patch;
+pub mod path;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,0 +1,90 @@
+//! RFC 7396 (JSON Merge Patch) core.
+//!
+//! [`merge_patch`] realizes the `MergePatch(Target, Patch)` pseudocode of
+//! RFC 7396 section 2, with one deliberate deviation inherited from the
+//! plana implementation (see below):
+//!
+//! - both sides objects → merged key by key; a `null` value in the patch
+//!   removes that key from the target;
+//! - anything else → the patch replaces the target wholesale.
+//!
+//! The deviations (both pinned in `tests/patch_compat.rs`): when the
+//! *patch* is an object but the *target* is not, strict RFC 7396 would
+//! reset the target to `{}` before merging (appendix-A case 14); this
+//! implementation instead returns the object patch verbatim, which lets
+//! [`PatchOp::set`](crate::patch::PatchOp::set) write null-bearing objects
+//! wholesale over non-object leaves. And the value of a key absent from
+//! the target is inserted verbatim without recursing (appendix-A case 15),
+//! so nulls nested inside newly-added objects survive. Together these keep
+//! the diff/apply roundtrip sound. The remaining trade-off — a top-level
+//! `null` member inside a wholesale-written object value is eaten when the
+//! target already is an object — is inherent to RFC 7396 ("not appropriate
+//! for documents that make use of explicit null values"); the state-tree
+//! domain uses nulls only as tombstones at leaf positions.
+//!
+//! The official appendix-A test cases of the RFC (plus the pinned A.14
+//! deviation) are exercised in `tests/patch_compat.rs`.
+
+use serde_json::Value;
+
+/// RFC 7396 merge patch: `target` is the current value, `patch` the new one.
+///
+/// - both objects → recursive key-wise merge (a `null` patch value deletes
+///   the target key, per RFC 7396 semantics);
+/// - otherwise → `patch` overwrites `target` outright (including
+///   `patch == null`, which yields `null`). Note that an *object* patch
+///   over a non-object target also lands here, returning the patch
+///   verbatim — the appendix-A case-14 deviation documented at the module
+///   level.
+///
+/// A target `null` under a key the patch does not mention is preserved —
+/// only *patch* nulls delete (RFC 7396 appendix A.13).
+pub fn merge_patch(target: Value, patch: Value) -> Value {
+    match (target, patch) {
+        (Value::Object(mut t), Value::Object(p)) => {
+            for (k, v) in p {
+                match v {
+                    // null = delete the key (RFC 7396 semantics).
+                    Value::Null => {
+                        t.remove(&k);
+                    }
+                    pv => {
+                        let merged = match t.remove(&k) {
+                            Some(tv) => merge_patch(tv, pv.clone()),
+                            None => pv,
+                        };
+                        t.insert(k, merged);
+                    }
+                }
+            }
+            Value::Object(t)
+        }
+        // Any non-object side → the patch wins (patch = null means deletion).
+        (_, p) => p,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Ported from plana `packages/sync/src/patch.rs` (compat baseline).
+
+    #[test]
+    fn merge_patch_object_recursive() {
+        let t = json!({"a":{"x":1,"y":2},"b":3});
+        let p = json!({"a":{"y":20,"z":3},"c":4});
+        assert_eq!(
+            merge_patch(t, p),
+            json!({"a":{"x":1,"y":20,"z":3},"b":3,"c":4})
+        );
+    }
+
+    #[test]
+    fn merge_patch_null_deletes_key() {
+        let t = json!({"a":{"x":1,"y":2}});
+        let p = json!({"a":{"x":null}});
+        assert_eq!(merge_patch(t, p), json!({"a":{"y":2}}));
+    }
+}

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,0 +1,278 @@
+//! Patch operations for the state-tree synchronization protocol.
+//!
+//! The state tree follows a "single server-side writer" model: every change
+//! originates server-side on a tree instance, is diffed against the previous
+//! version into a list of [`PatchOp`]s (see [`crate::diff`]) and broadcast to
+//! the clients subscribed to the matching viewport. Clients only ever
+//! [`apply`] — there is no concurrent-writer conflict handling on their side.
+//!
+//! The merge semantics are an RFC 7396 (JSON Merge Patch) variant:
+//!
+//! - `set` — deep merge: object keys merge one by one (the new value wins on
+//!   collision), non-objects replace outright;
+//! - `replace` — wholesale replacement, no deep merge. For enums /
+//!   tagged unions that must be swapped atomically (e.g. `work_status` going
+//!   from `{Running:{}}` to `{Completed:{}}`) — the deliberate core
+//!   difference from plain RFC 7396;
+//! - `del` — delete the key at the path (deleting the root resets it to an
+//!   empty object rather than `null`).
+//!
+//! This is deliberately simpler than full RFC 6902 JSON-Patch
+//! (add/remove/replace/move/copy/test): this scenario has no concurrent
+//! writers and no rename need, so the extra complexity buys nothing. Lost
+//! patches are healed by the periodic full-snapshot fallback pushed per
+//! active viewport, so the protocol self-recovers eventually.
+//!
+//! The serde representation is wire-locked to the historical `plana`
+//! `Sync.StatePatch` notification (`op` / `path` / optional `value`, with
+//! lowercase op tags); the golden-JSON tests in `tests/patch_compat.rs`
+//! pin it byte for byte.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::merge::merge_patch;
+use crate::path::split;
+
+/// A single patch operation. `path` is dot-separated (`state.agents.hubris`).
+///
+/// Serialized, this is exactly the `params` shape of the `Sync.StatePatch`
+/// notification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PatchOp {
+    pub op: PatchKind,
+    pub path: String,
+    /// With `set`/`replace`: the value to write. Always `None` for `del`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+}
+
+/// How a [`PatchOp`] writes at its target path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PatchKind {
+    /// Deep merge (RFC 7396): objects merge key by key, scalars/arrays
+    /// overwrite. For incremental updates such as partial field changes of
+    /// a complete agent object.
+    Set,
+    /// Wholesale replacement (no deep merge): the new value replaces the old
+    /// one entirely. For enums / tagged unions that must be swapped as a
+    /// whole (e.g. `work_status` from `{Running:{}}` to `{Completed:{}}`).
+    Replace,
+    /// Delete the key at the path.
+    Del,
+}
+
+impl PatchOp {
+    /// Builds a deep-merge (`set`) op.
+    pub fn set(path: impl Into<String>, value: Value) -> Self {
+        Self {
+            op: PatchKind::Set,
+            path: path.into(),
+            value: Some(value),
+        }
+    }
+
+    /// Builds a wholesale-replacement op.
+    pub fn replace(path: impl Into<String>, value: Value) -> Self {
+        Self {
+            op: PatchKind::Replace,
+            path: path.into(),
+            value: Some(value),
+        }
+    }
+
+    /// Builds a key-deletion op.
+    pub fn del(path: impl Into<String>) -> Self {
+        Self {
+            op: PatchKind::Del,
+            path: path.into(),
+            value: None,
+        }
+    }
+}
+
+/// Applies a single [`PatchOp`] to `root` (in place).
+///
+/// - `set` deep merge: descends along the path creating objects as needed,
+///   then RFC 7396 merges at the leaf;
+/// - `replace`: same descent, but the leaf value is replaced wholesale (no
+///   deep merge) — for enums / tagged unions that swap as a whole;
+/// - `del`: descends along the path and removes the final key.
+///
+/// Path descent auto-creates missing intermediate objects and promotes
+/// non-object nodes to empty objects along the way. An empty-path `set`
+/// merge-patches the root itself; an empty-path `replace` swaps the root;
+/// an empty-path `del` resets the root to an empty object (not `null`, so
+/// later descents keep working).
+pub fn apply(root: &mut Value, op: &PatchOp) {
+    let segments = split(&op.path);
+    match op.op {
+        PatchKind::Set => {
+            let Some(new_val) = op.value.clone() else {
+                return;
+            };
+            if segments.is_empty() {
+                *root = merge_patch(std::mem::take(root), new_val);
+                return;
+            }
+            let target = descend_mut(root, &segments);
+            *target = merge_patch(std::mem::take(target), new_val);
+        }
+        PatchKind::Replace => {
+            let Some(new_val) = op.value.clone() else {
+                return;
+            };
+            if segments.is_empty() {
+                *root = new_val;
+                return;
+            }
+            let target = descend_mut(root, &segments);
+            *target = new_val;
+        }
+        PatchKind::Del => {
+            if segments.is_empty() {
+                // Deleting the root = reset to an empty object (not
+                // Value::Null, or later path creation would fail).
+                *root = Value::Object(Map::new());
+                return;
+            }
+            let (parent_segs, leaf) = segments.split_at(segments.len() - 1);
+            let parent = descend_mut(root, parent_segs);
+            if let Value::Object(map) = parent {
+                map.remove(leaf[0]);
+            }
+        }
+    }
+}
+
+/// Applies a batch of ops in order. Used by clients merging a received
+/// patch list.
+pub fn apply_all(root: &mut Value, ops: &[PatchOp]) {
+    for op in ops {
+        apply(root, op);
+    }
+}
+
+/// Descends along `segments`, auto-creating missing object keys (as empty
+/// objects). Always returns the `&mut Value` at the leaf; root/intermediate
+/// non-object nodes are promoted to empty objects to keep the descent going.
+fn descend_mut<'a>(root: &'a mut Value, segments: &[&str]) -> &'a mut Value {
+    let mut cur = root;
+    for seg in segments {
+        // A non-object node becomes an empty object first (otherwise the
+        // descent could not continue).
+        if !cur.is_object() {
+            *cur = Value::Object(Map::new());
+        }
+        let map = cur.as_object_mut().expect("just promoted to object");
+        cur = map
+            .entry((*seg).to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+    }
+    cur
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Ported from plana `packages/sync/src/patch.rs` (compat baseline).
+
+    #[test]
+    fn set_creates_nested_objects() {
+        let mut root = json!({});
+        apply(
+            &mut root,
+            &PatchOp::set("state.agents.hubris", json!({"status":"idle"})),
+        );
+        assert_eq!(
+            root,
+            json!({"state":{"agents":{"hubris":{"status":"idle"}}}})
+        );
+    }
+
+    #[test]
+    fn set_deep_merges_objects() {
+        let mut root = json!({"state":{"agents":{"hubris":{"status":"idle","model":"gpt"}}}});
+        apply(
+            &mut root,
+            &PatchOp::set("state.agents.hubris", json!({"status":"busy"})),
+        );
+        // The model key survives (deep merge); status is overwritten.
+        assert_eq!(
+            root,
+            json!({"state":{"agents":{"hubris":{"status":"busy","model":"gpt"}}}})
+        );
+    }
+
+    #[test]
+    fn del_removes_key() {
+        let mut root = json!({"state":{"agents":{"hubris":{},"kalos":{}}}});
+        apply(&mut root, &PatchOp::del("state.agents.kalos"));
+        assert_eq!(root, json!({"state":{"agents":{"hubris":{}}}}));
+    }
+
+    #[test]
+    fn replace_overrides_without_deep_merge() {
+        // replace is for enums / tagged unions: wholesale swap, no deep merge.
+        let mut root = json!({"state":{"agents":{"hubris":{"work_status":{"Running":{}}}}}});
+        apply(
+            &mut root,
+            &PatchOp::replace("state.agents.hubris.work_status", json!({"Completed": {}})),
+        );
+        // Wholesale replacement — no Running residue.
+        assert_eq!(
+            root,
+            json!({"state":{"agents":{"hubris":{"work_status":{"Completed":{}}}}}})
+        );
+    }
+
+    #[test]
+    fn replace_creates_path() {
+        let mut root = json!({});
+        apply(
+            &mut root,
+            &PatchOp::replace("state.agents.hubris", json!({"x": 1})),
+        );
+        assert_eq!(root, json!({"state":{"agents":{"hubris":{"x":1}}}}));
+    }
+
+    // Additional coverage beyond the plana baseline.
+
+    #[test]
+    fn empty_path_targets_root() {
+        // set on the root = merge-patch the root itself.
+        let mut root = json!({"a":{"x":1}});
+        apply(&mut root, &PatchOp::set("", json!({"a":{"y":2},"b":3})));
+        assert_eq!(root, json!({"a":{"x":1,"y":2},"b":3}));
+
+        // replace on the root = swap it wholesale.
+        let mut root = json!({"a":1});
+        apply(&mut root, &PatchOp::replace("", json!([1, 2])));
+        assert_eq!(root, json!([1, 2]));
+
+        // del on the root = reset to an empty object (not null).
+        let mut root = json!({"a":1});
+        apply(&mut root, &PatchOp::del(""));
+        assert_eq!(root, json!({}));
+    }
+
+    #[test]
+    fn descent_promotes_non_objects() {
+        // A scalar mid-path becomes an empty object so the descent continues.
+        let mut root = json!({"agents": 7});
+        apply(
+            &mut root,
+            &PatchOp::set("agents.hubris.status", json!("busy")),
+        );
+        assert_eq!(root, json!({"agents":{"hubris":{"status":"busy"}}}));
+
+        // del through a missing path is a no-op (parents get created, the
+        // final key simply is not there).
+        let mut root = json!({});
+        apply(&mut root, &PatchOp::del("a.b.c"));
+        assert_eq!(root, json!({"a":{"b":{}}}));
+    }
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,139 @@
+//! Minimal dotted-path utilities for the patch/diff modules.
+//!
+//! Paths in the state-tree protocol are dot-separated
+//! (`state.agents.hubris`); the empty string denotes the root. There is no
+//! escaping — keys of the state tree are identifiers (UUIDs and the like)
+//! that never contain dots.
+//!
+//! Only the facilities needed by [`crate::patch`] and [`crate::diff`] live
+//! here; the viewport-path helpers stay with the snapshot module of a later
+//! migration phase.
+
+use std::fmt;
+
+/// Splits a dotted path into segments: `state.agents.hubris` →
+/// `["state","agents","hubris"]`. The empty path yields an empty vector
+/// (the root).
+///
+/// Migration note: this is `plana` `sync::patch::split_path`.
+pub fn split(path: &str) -> Vec<&str> {
+    segments(path).collect()
+}
+
+/// Iterates over the segments of a dotted path without allocating. The
+/// empty path yields no segments; trailing dots yield an empty final
+/// segment (exactly like `str::split('.')`).
+pub fn segments(path: &str) -> Segments<'_> {
+    Segments {
+        rest: path,
+        done: path.is_empty(),
+    }
+}
+
+/// Joins a path prefix and one more key: `("state.agents", "hubris")` →
+/// `"state.agents.hubris"`. An empty prefix denotes the root, so the key
+/// is returned alone.
+pub fn join(prefix: &str, key: &str) -> String {
+    if prefix.is_empty() {
+        key.to_string()
+    } else {
+        format!("{prefix}.{key}")
+    }
+}
+
+/// Renders a segment slice back into dotted form; see [`display`].
+pub struct DisplayPath<'a> {
+    parts: &'a [&'a str],
+}
+
+/// Wraps a segment slice so it formats as a dotted path:
+/// `display(&["state","agents"])` renders as `state.agents`. The empty
+/// slice renders as the empty string (the root).
+pub fn display<'a>(parts: &'a [&'a str]) -> DisplayPath<'a> {
+    DisplayPath { parts }
+}
+
+impl fmt::Display for DisplayPath<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, part) in self.parts.iter().enumerate() {
+            if i > 0 {
+                f.write_str(".")?;
+            }
+            f.write_str(part)?;
+        }
+        Ok(())
+    }
+}
+
+/// Borrowing iterator over the segments of a dotted path; see [`segments`].
+pub struct Segments<'a> {
+    rest: &'a str,
+    done: bool,
+}
+
+impl<'a> Iterator for Segments<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        match self.rest.split_once('.') {
+            Some((head, tail)) => {
+                self.rest = tail;
+                Some(head)
+            }
+            None => {
+                self.done = true;
+                Some(self.rest)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_matches_str_split() {
+        assert_eq!(split(""), Vec::<&str>::new());
+        assert_eq!(split("state"), vec!["state"]);
+        assert_eq!(
+            split("state.agents.hubris"),
+            vec!["state", "agents", "hubris"]
+        );
+        // Degenerate shapes stay faithful to `str::split('.')`.
+        assert_eq!(split("."), vec!["", ""]);
+        assert_eq!(split("a."), vec!["a", ""]);
+        assert_eq!(split(".a"), vec!["", "a"]);
+        assert_eq!(split("a..b"), vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn segments_iterator_equals_split() {
+        for path in ["", ".", "state", "state.agents.hubris", "a.", ".a", "a..b"] {
+            assert_eq!(segments(path).collect::<Vec<_>>(), split(path));
+        }
+    }
+
+    #[test]
+    fn join_handles_root_prefix() {
+        assert_eq!(join("", "state"), "state");
+        assert_eq!(join("state", "agents"), "state.agents");
+        assert_eq!(join("state.agents", "hubris"), "state.agents.hubris");
+    }
+
+    #[test]
+    fn display_roundtrips_split() {
+        assert_eq!(
+            display(&split("state.agents.hubris")).to_string(),
+            "state.agents.hubris"
+        );
+        assert_eq!(display(&[]).to_string(), "");
+        assert_eq!(display(&["a"]).to_string(), "a");
+        // Trailing/empty segments survive the roundtrip too.
+        assert_eq!(display(&split("a.")).to_string(), "a.");
+        assert_eq!(display(&split("a..b")).to_string(), "a..b");
+    }
+}

--- a/tests/patch_compat.rs
+++ b/tests/patch_compat.rs
@@ -1,0 +1,393 @@
+//! Compatibility suite for the state-patch runtime modules.
+//!
+//! Covers four things beyond the in-module unit tests (which are ported
+//! verbatim from `plana` `packages/sync/src/patch.rs` as the compat
+//! baseline):
+//!
+//! 1. the serde wire format of [`yuuka::patch::PatchOp`] — pinned byte for
+//!    byte against the historical `plana` `Sync.StatePatch` params shape;
+//! 2. the official RFC 7396 appendix-A test cases against
+//!    [`yuuka::merge::merge_patch`] (plus the one deliberate deviation
+//!    inherited from plana, case A.14);
+//! 3. a property-based roundtrip: `apply_all(diff(b, a))` reconstructs `a`
+//!    from random trees;
+//! 4. proof that the yuuka API covers the entire pub surface of plana's
+//!    `sync::patch` module.
+
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// 1. Golden JSON: the wire format must match plana byte for byte.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn golden_set_op_serializes_like_plana() {
+    let op = yuuka::patch::PatchOp::set("state.agents.hubris", json!({"status":"idle"}));
+    // Field order (op, path, value) and the lowercase op tag are locked.
+    assert_eq!(
+        serde_json::to_string(&op).unwrap(),
+        r#"{"op":"set","path":"state.agents.hubris","value":{"status":"idle"}}"#
+    );
+    assert_eq!(
+        serde_json::to_value(&op).unwrap(),
+        json!({"op":"set","path":"state.agents.hubris","value":{"status":"idle"}})
+    );
+}
+
+#[test]
+fn golden_replace_op_serializes_like_plana() {
+    let op = yuuka::patch::PatchOp::replace("state.work_status", json!({"Running":{"code":1}}));
+    assert_eq!(
+        serde_json::to_string(&op).unwrap(),
+        r#"{"op":"replace","path":"state.work_status","value":{"Running":{"code":1}}}"#
+    );
+    assert_eq!(
+        serde_json::to_value(&op).unwrap(),
+        json!({"op":"replace","path":"state.work_status","value":{"Running":{"code":1}}})
+    );
+}
+
+#[test]
+fn golden_del_op_omits_the_value_key() {
+    let op = yuuka::patch::PatchOp::del("state.agents.kalos");
+    // `value` is skipped entirely — the wire object has exactly two keys.
+    assert_eq!(
+        serde_json::to_string(&op).unwrap(),
+        r#"{"op":"del","path":"state.agents.kalos"}"#
+    );
+    let as_value = serde_json::to_value(&op).unwrap();
+    assert_eq!(as_value.as_object().unwrap().len(), 2);
+    assert!(as_value.get("value").is_none());
+}
+
+#[test]
+fn golden_patch_kind_tags_are_lowercase() {
+    use yuuka::patch::PatchKind;
+    assert_eq!(serde_json::to_value(PatchKind::Set).unwrap(), json!("set"));
+    assert_eq!(
+        serde_json::to_value(PatchKind::Replace).unwrap(),
+        json!("replace")
+    );
+    assert_eq!(serde_json::to_value(PatchKind::Del).unwrap(), json!("del"));
+}
+
+#[test]
+fn patch_ops_deserialize_like_plana() {
+    use yuuka::patch::{PatchKind, PatchOp};
+
+    let set: PatchOp = serde_json::from_str(r#"{"op":"set","path":"p","value":42}"#).unwrap();
+    assert_eq!(set, PatchOp::set("p", json!(42)));
+
+    let replace: PatchOp =
+        serde_json::from_str(r#"{"op":"replace","path":"p","value":{"a":1}}"#).unwrap();
+    assert_eq!(replace, PatchOp::replace("p", json!({"a":1})));
+
+    let del: PatchOp = serde_json::from_str(r#"{"op":"del","path":"p"}"#).unwrap();
+    assert_eq!(del, PatchOp::del("p"));
+    assert_eq!(del.value, None);
+    assert_eq!(del.op, PatchKind::Del);
+
+    // An explicit JSON null for `value` also lands as `None` (plana
+    // behavior: the skip only affects serialization).
+    let del_null: PatchOp =
+        serde_json::from_str(r#"{"op":"del","path":"p","value":null}"#).unwrap();
+    assert_eq!(del_null, PatchOp::del("p"));
+}
+
+#[test]
+fn patch_op_serde_roundtrips_through_value() {
+    use yuuka::patch::PatchOp;
+
+    for op in [
+        PatchOp::set("state.a.b", json!({"x":[1,2],"y":"z"})),
+        PatchOp::replace("state.c", json!("done")),
+        PatchOp::del("state.d.e"),
+    ] {
+        let back: PatchOp = serde_json::from_value(serde_json::to_value(&op).unwrap()).unwrap();
+        assert_eq!(back, op);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. RFC 7396 appendix A: the official example test cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merge_patch_passes_rfc7396_appendix_a() {
+    // Cases A.1–A.13 of the RFC, verbatim. (A.14 and A.15 are the two
+    // deliberate plana deviations — see
+    // `merge_patch_appendix_a_deviation_cases_are_pinned`.)
+    let cases: &[(Value, Value, Value)] = &[
+        (json!({"a":"b"}), json!({"a":"c"}), json!({"a":"c"})),
+        (json!({"a":"b"}), json!({"b":"c"}), json!({"a":"b","b":"c"})),
+        (json!({"a":"b"}), json!({"a":null}), json!({})),
+        (
+            json!({"a":"b","b":"c"}),
+            json!({"a":null}),
+            json!({"b":"c"}),
+        ),
+        (json!({"a":["b"]}), json!({"a":"c"}), json!({"a":"c"})),
+        (json!({"a":"c"}), json!({"a":["b"]}), json!({"a":["b"]})),
+        (
+            json!({"a":{"b":"c"}}),
+            json!({"a":{"b":"d","c":null}}),
+            json!({"a":{"b":"d"}}),
+        ),
+        (json!({"a":[{"b":"c"}]}), json!({"a":[1]}), json!({"a":[1]})),
+        (json!(["a", "b"]), json!(["c", "d"]), json!(["c", "d"])),
+        (json!({"a":"b"}), json!(["c"]), json!(["c"])),
+        (json!({"a":"foo"}), json!(null), json!(null)),
+        (json!({"a":"foo"}), json!("bar"), json!("bar")),
+        (json!({"e":null}), json!({"a":1}), json!({"e":null,"a":1})),
+    ];
+    assert_eq!(cases.len(), 13, "appendix-A cases 1-13 must be present");
+    for (i, (original, patch, expected)) in cases.iter().enumerate() {
+        assert_eq!(
+            yuuka::merge::merge_patch(original.clone(), patch.clone()),
+            *expected,
+            "RFC 7396 appendix A case {} failed",
+            i + 1
+        );
+    }
+}
+
+#[test]
+fn merge_patch_appendix_a_deviation_cases_are_pinned() {
+    // Case A.14: original [1,2], patch {"a":"b","c":null}. Strict RFC 7396
+    // would reset the non-object target to {} before merging and produce
+    // {"a":"b"}. The plana variant — kept verbatim here — returns the
+    // object patch wholesale instead, because `PatchOp::set` must be able
+    // to write null-bearing objects over non-object leaves for the
+    // diff/apply roundtrip to hold. See
+    // `nested_null_members_documented_limitation` for the other side of
+    // this trade-off.
+    assert_eq!(
+        yuuka::merge::merge_patch(json!([1, 2]), json!({"a":"b","c":null})),
+        json!({"a":"b","c":null})
+    );
+
+    // Case A.15: original {}, patch {"a":{"bb":{"ccc":null}}}. Strict RFC
+    // 7396 recurses into newly-added values and strips their null members
+    // ({"a":{"bb":{}}}); the plana variant inserts the value of an absent
+    // key verbatim, so nulls nested inside newly-added objects survive.
+    // This is what lets `diff`+`set` reproduce deeply null-bearing trees.
+    assert_eq!(
+        yuuka::merge::merge_patch(json!({}), json!({"a":{"bb":{"ccc":null}}})),
+        json!({"a":{"bb":{"ccc":null}}})
+    );
+}
+
+#[test]
+fn nested_null_members_documented_limitation() {
+    // RFC 7396 cannot distinguish "delete key" from "set key to null": a
+    // null member inside a *wholesale-set* object value is eaten by the
+    // deep merge when the target at that path is an object (or was just
+    // auto-created by the descent). plana semantics, kept as-is — the
+    // state-tree domain uses nulls only as tombstones at leaf positions.
+    let mut root = json!({"x": {}});
+    yuuka::patch::apply(
+        &mut root,
+        &yuuka::patch::PatchOp::set("x", json!({"a":null,"b":1})),
+    );
+    assert_eq!(root, json!({"x":{"b":1}})); // "a" eaten by the deep merge
+
+    // Over a non-object leaf the object patch replaces wholesale — nulls
+    // survive (the case-A.14 deviation working as intended).
+    let mut root = json!({"x": 5});
+    yuuka::patch::apply(
+        &mut root,
+        &yuuka::patch::PatchOp::set("x", json!({"a":null,"b":1})),
+    );
+    assert_eq!(root, json!({"x":{"a":null,"b":1}}));
+
+    // Nulls as *whole leaf values* roundtrip fine, including inside
+    // objects that diff walks key by key.
+    for (before, after) in [
+        (json!({}), json!({"a":null})),
+        (json!({"a":1}), json!({"a":null})),
+        (json!({"a":{"x":1}}), json!({"a":null})),
+        (json!({"a":null}), json!({"a":{"x":1}})),
+        (json!({"k":{"x":1}}), json!({"k":{"x":null,"z":1}})),
+    ] {
+        let mut rebuilt = before.clone();
+        yuuka::patch::apply_all(&mut rebuilt, &yuuka::diff::diff("", &before, &after));
+        assert_eq!(rebuilt, after, "before={before}, after={after}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Property roundtrip: apply_all(diff(before, after)) == after.
+// ---------------------------------------------------------------------------
+
+/// Deterministic xorshift64* PRNG — enough randomness for tree fuzzing
+/// without pulling in a dependency.
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+/// Keys never contain dots (state-tree convention), and come from a tiny
+/// alphabet so before/after key sets collide and exercise add/change/del.
+const KEYS: [&str; 4] = ["a", "b", "c", "d"];
+
+/// Leaves are null-free: a null member inside a wholesale-written object
+/// value cannot survive the RFC 7396 deep merge (see
+/// `nested_null_members_documented_limitation`), so the roundtrip property
+/// holds on the state-tree domain of null-free object members. Nulls as
+/// whole leaf values are covered by the hand-picked cases above.
+fn leaf(rng: &mut Rng) -> Value {
+    match rng.below(8) {
+        0 => json!(""),
+        1 => json!(true),
+        2 => json!(false),
+        3 => json!(0),
+        4 => json!(7),
+        5 => json!(-3),
+        6 => json!("text"),
+        _ => json!(0.5),
+    }
+}
+
+fn gen_value(rng: &mut Rng, depth: u32) -> Value {
+    if depth == 0 {
+        return leaf(rng);
+    }
+    match rng.below(10) {
+        0..=3 => leaf(rng),
+        4..=7 => {
+            let mut map = serde_json::Map::new();
+            for _ in 0..rng.below(4) {
+                let key = KEYS[rng.below(KEYS.len() as u64) as usize];
+                let value = gen_value(rng, depth - 1);
+                map.insert(key.to_string(), value);
+            }
+            Value::Object(map)
+        }
+        _ => {
+            let items: Vec<Value> = (0..rng.below(3))
+                .map(|_| gen_value(rng, depth - 1))
+                .collect();
+            Value::Array(items)
+        }
+    }
+}
+
+#[test]
+fn property_diff_apply_roundtrip() {
+    // `seed | 1` keeps xorshift away from its all-zero fixed point.
+    for seed in [1u64, 2, 7, 42, 0xDEAD_BEEF, 0x0123_4567_89AB_CDEF] {
+        let mut rng = Rng(seed | 1);
+        for _ in 0..200 {
+            let before = gen_value(&mut rng, 4);
+            let after = gen_value(&mut rng, 4);
+            let mut rebuilt = before.clone();
+            yuuka::patch::apply_all(&mut rebuilt, &yuuka::diff::diff("", &before, &after));
+            assert_eq!(
+                rebuilt, after,
+                "roundtrip failed for seed {seed}: before={before}, after={after}"
+            );
+        }
+    }
+}
+
+#[test]
+fn diff_apply_roundtrip_on_root_type_swaps() {
+    // Hand-picked adversarial pairs around the root and type swaps.
+    let cases: &[(Value, Value)] = &[
+        (json!(null), json!({})),
+        (json!({}), json!(null)),
+        (json!(5), json!({"a": {"b": "x"}})),
+        (json!({"a": {"b": "x"}}), json!(5)),
+        (json!({"a": {"b": 1}}), json!({"a": 1})),
+        (json!({"a": 1}), json!({"a": {"b": 1}})),
+        (json!([1, [2]]), json!({"a": [1, [2]]})),
+        (json!({"a": [1, [2]]}), json!([1, [2]])),
+        (json!({"a": "x"}), json!({})),
+    ];
+    for (before, after) in cases {
+        let mut rebuilt = before.clone();
+        yuuka::patch::apply_all(&mut rebuilt, &yuuka::diff::diff("", before, after));
+        assert_eq!(
+            &rebuilt, after,
+            "roundtrip failed: before={before}, after={after}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. API coverage of plana `sync::patch`'s entire pub surface.
+// ---------------------------------------------------------------------------
+//
+// Mapping (plana → yuuka):
+//
+// | plana `sync::patch`            | yuuka                       |
+// |--------------------------------|-----------------------------|
+// | `PatchOp` (struct + 3 ctors)   | `yuuka::patch::PatchOp`     |
+// | `PatchKind`                    | `yuuka::patch::PatchKind`   |
+// | `apply` / `apply_all`          | `yuuka::patch::apply*`      |
+// | `merge_patch`                  | `yuuka::merge::merge_patch` |
+// | `diff`                         | `yuuka::diff::diff`         |
+// | `split_path`                   | `yuuka::path::split`        |
+
+#[test]
+fn api_surface_matches_plana_patch_module() {
+    use yuuka::patch::{self, PatchKind, PatchOp};
+
+    // Function-pointer coercions pin the exact signatures plana callers
+    // rely on.
+    let merge_patch: fn(Value, Value) -> Value = yuuka::merge::merge_patch;
+    let apply: fn(&mut Value, &PatchOp) = patch::apply;
+    let apply_all: fn(&mut Value, &[PatchOp]) = patch::apply_all;
+    let diff: fn(&str, &Value, &Value) -> Vec<PatchOp> = yuuka::diff::diff;
+    let split: fn(&str) -> Vec<&str> = yuuka::path::split;
+
+    // Constructors build the documented shapes.
+    let set_op = PatchOp::set("state.a", json!(1));
+    let replace_op = PatchOp::replace("state.b", json!([1]));
+    let del_op = PatchOp::del("state.c");
+    assert_eq!(set_op.op, PatchKind::Set);
+    assert_eq!(replace_op.op, PatchKind::Replace);
+    assert_eq!(del_op.op, PatchKind::Del);
+
+    // The struct fields are public.
+    let PatchOp { op, path, value } = &set_op;
+    assert_eq!(*op, PatchKind::Set);
+    assert_eq!(path, "state.a");
+    assert_eq!(*value, Some(json!(1)));
+    assert_eq!(del_op.value, None);
+
+    // Derives required by plana callers: Debug/Clone/PartialEq on both
+    // types (asserted via use), plus Copy/Eq on PatchKind.
+    fn assert_derives<T: std::fmt::Debug + Clone + PartialEq>(v: T) -> T {
+        v
+    }
+    let copied_kind = PatchKind::Set;
+    let moved_kind = copied_kind;
+    assert_eq!(copied_kind, moved_kind); // still usable → PatchKind: Copy.
+    let cloned_op = assert_derives(set_op.clone());
+    let kind = assert_derives(copied_kind);
+    assert!(format!("{cloned_op:?}").contains("PatchOp"));
+    assert!(format!("{kind:?}").contains("Set"));
+
+    // The full pipeline runs through the yuuka paths: set writes a,
+    // replace writes b, del of the absent c is a no-op.
+    let mut root = json!({});
+    apply(&mut root, &set_op);
+    apply_all(&mut root, &[replace_op, del_op]);
+    assert_eq!(root, json!({"state":{"a":1,"b":[1]}}));
+    assert!(diff("state", &root, &root).is_empty());
+    assert_eq!(split("state.a"), vec!["state", "a"]);
+    assert_eq!(merge_patch(json!({}), json!({"x":1})), json!({"x":1}));
+}


### PR DESCRIPTION
## Summary

Migrates the JSON merge/patch/diff runtime facilities from plana_sync into yuuka as four new facade modules, the first step of upgrading yuuka from a pure macro crate into the org's JSON merge/patch foundation library.

## Changes

- `src/merge.rs` — RFC 7396 merge-patch core (`merge_patch`), documenting the two deliberate plana-inherited deviations (appendix-A cases 14/15) that the diff/apply roundtrip depends on.
- `src/patch.rs` — `PatchOp` / `PatchKind` / `apply` / `apply_all`; serde wire format byte-identical to plana's `Sync.StatePatch` payload (golden JSON tests lock field order, lowercase kind renames, and the `skip_serializing_if` behaviour).
- `src/diff.rs` — replace-semantics tree diff with the dels-before-sets ordering and the roundtrip guarantee `apply_all(a, diff(a,b)) == b`.
- `src/path.rs` — dotted-path primitives (`split` / `segments` / `join` / `display`); viewport helpers intentionally deferred to a follow-up stage.
- Version 0.7.0 → **0.8.0** (workspace + facade dep on yuuka-macros).
- serde / serde_json move from dev-dependencies to dependencies.

## Verification (3-round cycle, 3/3 PASS)

- 29 new tests green (plana's 10 unit tests ported verbatim, RFC 7396 appendix A suite incl. pinned deviations, golden wire JSON, 1200-pair property roundtrip, API-surface pin).
- Independent differential fuzzing: yuuka vs plana's compiled patch.rs on 12,000 randomized inputs — zero behavioural or wire-byte divergence.
- 16 test targets green; clippy -D warnings clean; fmt clean; zero unsafe.
- Publish path simulated offline (vendored macros 0.8.0): facade packages cleanly with the path dep rewritten to the registry version — publish.yml's macros-first order is confirmed sufficient.

## Follow-ups (recorded, not blocking)

- README / crates.io description / keywords still describe macro-only scope — to be refreshed in the final polish stage before 1.0.0-rc.
- kirino's git dep on yuuka carries a stale `version = "^0.6"` key that fails fresh resolution against master ≥0.7 (pre-existing since #18; existing lockfiles are unaffected). A small kirino PR will drop the key.