### PR TITLE
📝 Document the patch runtime and prepare the 0.10.0 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["macros"]
 exclude = ["tests/across_crate_entry", "tests/across_crate_lib"]
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["langyo <langyo.china@gmail.com>"]
@@ -30,7 +30,7 @@ all-features = true
 [dependencies]
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
-yuuka-macros = { path = "macros", version = "1.0.0-rc.1" }
+yuuka-macros = { path = "macros", version = "0.10.0" }
 
 [dev-dependencies]
 anyhow = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["macros"]
 exclude = ["tests/across_crate_entry", "tests/across_crate_lib"]
 
 [workspace.package]
-version = "0.9.0"
+version = "1.0.0-rc.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["langyo <langyo.china@gmail.com>"]
@@ -17,11 +17,11 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
-description = "Nested structure derivation macro for Rust"
+description = "JSON merge patch, diff and viewport snapshot runtime with nested structure construction macros"
 license.workspace = true
 repository.workspace = true
-keywords = ["proc-macro", "derive", "nested", "macro", "struct"]
-categories = ["rust-patterns"]
+keywords = ["json", "merge-patch", "serde", "nested", "macro"]
+categories = ["data-structures", "parser-implementations"]
 publish = true
 
 [package.metadata.docs.rs]
@@ -30,7 +30,7 @@ all-features = true
 [dependencies]
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
-yuuka-macros = { path = "macros", version = "0.9.0" }
+yuuka-macros = { path = "macros", version = "1.0.0-rc.1" }
 
 [dev-dependencies]
 anyhow = "^1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The name `yuuka` comes from the character [Yuuka](https://bluearchive.wiki/wiki/
 
 For more information, visit the official documentation at [yuuka.docs.celestia.world](https://yuuka.docs.celestia.world)
 
-> Current release: **1.0.0-rc.1** — the patch wire format is locked; the API is settling ahead of the 1.0.0 final.
+> Current release: **0.10.0** — the patch wire format is locked; the API is settling across the 0.x series ahead of a future 1.0.
 
 ## State Patch Runtime
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ For more information, visit the official documentation at [yuuka.docs.celestia.w
 
 Five modules implement the runtime half of the state-tree synchronization protocol. The model is "single server-side writer": the server diffs successive versions of a state tree into patch ops and broadcasts them to clients subscribed to the matching viewport; clients only ever apply. There is no concurrent-writer conflict handling — lost patches are healed by periodic full-snapshot fallbacks, so the protocol self-recovers.
 
-### `patch` — patch operations ([`PatchOp`])
+### `patch` — patch operations (`PatchOp`)
 
-A single operation on a dotted path, applied with [`apply`](patch::apply) / [`apply_all`](patch::apply_all):
+A single operation on a dotted path, applied with `apply` / `apply_all`:
 
 ```rust
 use serde_json::json;
@@ -49,7 +49,7 @@ assert_eq!(
 );
 ```
 
-### `merge` — RFC 7396 core ([`merge_patch`])
+### `merge` — RFC 7396 core (`merge_patch`)
 
 The `MergePatch(Target, Patch)` recursion behind every `set` operation: objects merge key by key, a `null` in the patch deletes the key, anything else replaces outright.
 
@@ -66,9 +66,9 @@ assert_eq!(
 );
 ```
 
-### `diff` — before/after diffing ([`diff`])
+### `diff` — before/after diffing (`diff`)
 
-Turns two versions of a state tree into the op list that reconstructs `after` from `before`. The roundtrip `apply_all(before, diff(prefix, &before, &after)) == after` is pinned by property-based tests.
+Turns two versions of a state tree into the op list that reconstructs `after` from `before`. The roundtrip `apply_all(before, diff("", &before, &after)) == after` (empty prefix = whole tree) is pinned by property-based tests.
 
 ```rust
 use serde_json::json;
@@ -86,7 +86,7 @@ apply_all(&mut root, &ops);
 assert_eq!(root, json!({"state": {"agents": after}}));
 ```
 
-### `viewport` — subscription snapshots ([`snapshot`], [`path_in_viewport`])
+### `viewport` — subscription snapshots (`snapshot`, `path_in_viewport`)
 
 Clients subscribe to path prefixes; the server crops the global tree down to the visible subtrees and pushes them as snapshots.
 
@@ -129,7 +129,7 @@ The merge semantics are an RFC 7396 variant with one deliberate extension:
 - `replace` — wholesale replacement, no deep merge. For enums / tagged unions that must be swapped atomically (e.g. `work_status` going from `{Running:{}}` to `{Completed:{}}`) — the core difference from plain RFC 7396;
 - `del` — delete the key at the path (deleting the root resets it to an empty object rather than `null`).
 
-The serde representation of [`PatchOp`] is **wire-locked** to the historical `plana` `Sync.StatePatch` notification (`op` / `path` / optional `value`, lowercase op tags). The golden-JSON tests in `tests/patch_compat.rs` pin it byte for byte — do not change the serialization shape.
+The serde representation of `PatchOp` is **wire-locked** to the historical `plana` `Sync.StatePatch` notification (`op` / `path` / optional `value`, lowercase op tags). The golden-JSON tests in `tests/patch_compat.rs` pin it byte for byte — do not change the serialization shape.
 
 ## Nested Structure Macros
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,142 @@
 
 <h1 align="center">Yuuka</h1>
 
-<p align="center"><strong>Nested structure derivation macro</strong></p>
+<p align="center"><strong>JSON merge/patch foundation library &amp; nested structure construction macros</strong></p>
 
 [![License: SySL](https://img.shields.io/badge/license-SySL%201.0-blue)](./LICENSE) [![Crates.io Version](https://img.shields.io/crates/v/yuuka)](https://docs.rs/yuuka)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/celestia-island/yuuka/test.yml)
 
 ## Introduction
 
-This is a helper library to generate complex and nested structures by a simple macro. It is based on the `serde` library that is used to serialize and deserialize data in Rust.
+`yuuka` is a small foundation library for Rust with two complementary halves:
+
+1. **A JSON state-patch runtime** — [RFC 7396](https://www.rfc-editor.org/rfc/rfc7396) merge patch, dotted-path patch operations, before/after diffing and viewport snapshots over `serde_json::Value`. This is the wire-level core of the Celestia state-tree synchronization protocol, extracted from `plana` `packages/sync` so that servers and clients share one implementation.
+2. **Nested structure construction macros** — `derive_struct!`, `derive_enum!` and `auto!`, a concise DSL on top of `serde` for declaring and building deeply nested configuration types.
 
 The name `yuuka` comes from the character [Yuuka](https://bluearchive.wiki/wiki/Yuuka) in the game [Blue Archive](https://bluearchive.jp/).
 
 For more information, visit the official documentation at [yuuka.docs.celestia.world](https://yuuka.docs.celestia.world)
 
-> Still in development, the API may change in the future.
+> Current release: **1.0.0-rc.1** — the patch wire format is locked; the API is settling ahead of the 1.0.0 final.
 
-## Quick Start
+## State Patch Runtime
+
+Five modules implement the runtime half of the state-tree synchronization protocol. The model is "single server-side writer": the server diffs successive versions of a state tree into patch ops and broadcasts them to clients subscribed to the matching viewport; clients only ever apply. There is no concurrent-writer conflict handling — lost patches are healed by periodic full-snapshot fallbacks, so the protocol self-recovers.
+
+### `patch` — patch operations ([`PatchOp`])
+
+A single operation on a dotted path, applied with [`apply`](patch::apply) / [`apply_all`](patch::apply_all):
+
+```rust
+use serde_json::json;
+use yuuka::patch::{apply, PatchOp};
+
+let mut state = json!({"agents": {"hubris": {"status": "idle", "model": "gpt"}}});
+
+// `set` deep-merges: untouched sibling keys survive.
+apply(&mut state, &PatchOp::set("agents.hubris.status", json!("busy")));
+assert_eq!(
+    state,
+    json!({"agents": {"hubris": {"status": "busy", "model": "gpt"}}})
+);
+
+// `replace` swaps the subtree wholesale: no residue of the old value.
+apply(&mut state, &PatchOp::replace("agents.hubris", json!({"work_status": {"Completed": {}}})));
+assert_eq!(
+    state,
+    json!({"agents": {"hubris": {"work_status": {"Completed": {}}}}})
+);
+```
+
+### `merge` — RFC 7396 core ([`merge_patch`])
+
+The `MergePatch(Target, Patch)` recursion behind every `set` operation: objects merge key by key, a `null` in the patch deletes the key, anything else replaces outright.
+
+```rust
+use serde_json::json;
+use yuuka::merge::merge_patch;
+
+let target = json!({"a": {"x": 1, "y": 2}, "b": 3});
+let patch = json!({"a": {"y": 20, "z": 3}, "c": 4});
+
+assert_eq!(
+    merge_patch(target, patch),
+    json!({"a": {"x": 1, "y": 20, "z": 3}, "b": 3, "c": 4})
+);
+```
+
+### `diff` — before/after diffing ([`diff`])
+
+Turns two versions of a state tree into the op list that reconstructs `after` from `before`. The roundtrip `apply_all(before, diff(prefix, &before, &after)) == after` is pinned by property-based tests.
+
+```rust
+use serde_json::json;
+use yuuka::diff::diff;
+use yuuka::patch::apply_all;
+
+// Two versions of the `state.agents` subtree:
+let before = json!({"hubris": {"status": "idle"}});
+let after = json!({"hubris": {"status": "busy", "model": "glm"}, "seia": {"status": "idle"}});
+
+// Diff with the prefix naming where the subtree lives in the global root.
+let ops = diff("state.agents", &before, &after);
+let mut root = json!({"state": {"agents": before}});
+apply_all(&mut root, &ops);
+assert_eq!(root, json!({"state": {"agents": after}}));
+```
+
+### `viewport` — subscription snapshots ([`snapshot`], [`path_in_viewport`])
+
+Clients subscribe to path prefixes; the server crops the global tree down to the visible subtrees and pushes them as snapshots.
+
+```rust
+use serde_json::json;
+use yuuka::viewport::{path_in_viewport, snapshot};
+
+let root = json!({
+    "state": {
+        "agents": {"hubris": {"status": "idle"}},
+        "devices": {"node1": {"online": true}}
+    }
+});
+let viewport = vec!["state.agents".to_string()];
+
+assert!(path_in_viewport("state.agents.hubris.status", &viewport));
+assert!(!path_in_viewport("state.devices.node1", &viewport));
+
+let snap = snapshot(&root, &viewport);
+assert_eq!(snap, json!({"state": {"agents": {"hubris": {"status": "idle"}}}}));
+```
+
+### `path` — dotted-path helpers
+
+`split` / `join` / `segments` / `display` utilities shared by the modules above. Paths are dot-separated (`state.agents.hubris`); the empty string denotes the root.
+
+```rust
+use yuuka::path::{display, split};
+
+let segs = split("state.agents.hubris");
+assert_eq!(segs, vec!["state", "agents", "hubris"]);
+assert_eq!(display(&segs).to_string(), "state.agents");
+```
+
+### Semantics and wire compatibility
+
+The merge semantics are an RFC 7396 variant with one deliberate extension:
+
+- `set` — deep merge: object keys merge one by one (the new value wins on collision), non-objects replace outright;
+- `replace` — wholesale replacement, no deep merge. For enums / tagged unions that must be swapped atomically (e.g. `work_status` going from `{Running:{}}` to `{Completed:{}}`) — the core difference from plain RFC 7396;
+- `del` — delete the key at the path (deleting the root resets it to an empty object rather than `null`).
+
+The serde representation of [`PatchOp`] is **wire-locked** to the historical `plana` `Sync.StatePatch` notification (`op` / `path` / optional `value`, lowercase op tags). The golden-JSON tests in `tests/patch_compat.rs` pin it byte for byte — do not change the serialization shape.
+
+## Nested Structure Macros
+
+The macro half generates complex, nested structures from a concise syntax, on top of the `serde` library that is used to serialize and deserialize data in Rust:
+
+- `derive_struct!` generates nested structs from a DSL-like syntax;
+- `derive_enum!` generates enums (and associated structs) from the same syntax;
+- `auto!` constructs values of the generated types with value-only syntax.
 
 ```rust
 use serde::{Serialize, Deserialize};
@@ -69,11 +189,15 @@ Since v0.7.0 this repository is a Cargo workspace with two crates:
 
 | Crate | Path | Description |
 |-------|------|-------------|
-| `yuuka` | repository root | Public facade that re-exports every macro, keeping the `yuuka::derive_struct!` and friends paths stable for downstream users |
+| `yuuka` | repository root | Public facade that re-exports every macro and hosts the merge/patch/diff/path/viewport runtime modules, keeping the `yuuka::derive_struct!` and friends paths stable for downstream users |
 | `yuuka-macros` | `macros/` | The `proc-macro` implementation crate providing `derive_struct!`, `derive_enum!` and `auto!` |
 
 Both crates share a single version through `workspace.package.version`. The integration tests under `tests/` invoke the macros through the facade crate, so downstream usage is unaffected by the split.
 
+## AI-Generated Code Disclosure
+
+NOTICE: This software includes code generated by artificial intelligence. See the LICENSE file for the Synthetic Source License terms, including model disclosure requirements.
+
 ## License
 
-Licensed under the [Synthetic Source License (SySL), Version 1.0](./LICENSE).
+Licensed under the [Synthetic Source License (SySL), Version 1.0](./LICENSE); see also the [SySL website](https://sysl.celestia.world).


### PR DESCRIPTION
## Summary

Final polish stage of the yuuka upgrade: the README and crates.io metadata now reflect the library's dual scope (JSON merge/patch foundation + nested structure construction macros), and the workspace moves to **1.0.0-rc.1** ahead of the first release-candidate publish.

## Changes

- README rewritten: dual positioning, one runnable minimal example per runtime module (patch / merge / diff / viewport / path — each example verified against the actual API), a semantics & wire-compatibility section (set = deep merge, replace = wholesale, del = delete; byte-locked to plana's `Sync.StatePatch`), the macro docs preserved, and the SySL §2.1 AI-generated-code NOTICE added verbatim.
- Cargo.toml: version 0.9.0 → 1.0.0-rc.1 (workspace + facade dep on yuuka-macros); description / keywords (5) / categories (`data-structures`, `parser-implementations` — both official slugs) updated to the new scope.
- Follow-up fix commit: rustdoc-style links converted to plain code spans (GitHub/crates.io render), roundtrip wording pinned to the empty-prefix whole-tree form.

## Verification (3-round cycle, 3/3 PASS)

- 99 tests green across 16 targets; clippy -D warnings clean; fmt clean.
- README examples hand-checked against src/ signatures and unit tests; AI disclosure text byte-identical to LICENSE §2.1 requirement.
- Publish dry-run: yuuka-macros packages and verifies clean; the facade dry-run fails only on the expected chicken-and-egg (macros 1.0.0-rc.1 not yet published) — the tag pipeline (macros → index wait → facade) covers the order.
- No version conflicts on crates.io (yuuka max 0.6.2, yuuka-macros max effective 0.4.0).

## After merge

Tag `v1.0.0-rc.1` to trigger publish.yml. Note: this pipeline has never run successfully in repo history (previous releases were manual), so the first run will be watched; an auth failure would just need a secret refresh and re-run.