### PR TITLE
🔧 Drop synchronize from message checks and pin checkout to v7.

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -24,7 +24,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -2,7 +2,7 @@ name: Commit Message Lint
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install --git https://github.com/celestia-island/lagrange --branch dev lagrange-library --locked

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
CI slim wave (AGENTS.md 7.4, PLAN.md claim 2026-08-31): message-check workflows now trigger only on opened/edited/reopened/ready_for_review instead of every push (synchronize), and actions/checkout is pinned to v7 org-wide — the self-hosted runners' action cache keeps only the latest downloaded version per action repo, so mixing v4/v5/v7 forces a 30s-2.5min re-download per job through the proxy. All changed YAML validated locally (yaml.safe_load_all).